### PR TITLE
update data-to-sign syntax to fit current Akamai Luna API criteria

### DIFF
--- a/src/edgegridclj/canonicalize.clj
+++ b/src/edgegridclj/canonicalize.clj
@@ -42,6 +42,6 @@
   (str (.toUpperCase (.getRequestMethod request)) \tab
        (.toLowerCase (.getScheme (.toURI (.getUrl request)))) \tab
        (.getFirstHeaderStringValue (.getHeaders request) "host") \tab
-       (canonicalizeUri (.buildRelativeUrl (.getUrl request))) \tab
+       (canonicalizeUri (.buildRelativeUrl (.getUrl request))) \tab\tab
        (apply str (map (partial canonicalizeHeader request) headers-to-use))
        (getContentHash request) \tab))

--- a/src/edgegridclj/sign.clj
+++ b/src/edgegridclj/sign.clj
@@ -56,7 +56,7 @@
                                          timestamp)
         signingKey    (aka-open-inner-sign timestamp (:clientSecret cred) HMAC_ALG)
         requestResult (aka-open-canonicalize request) ;; TBD handle non-retryable case
-        stringToSign  (str authData requestResult)
+        stringToSign  (str requestResult authData)
         signature     (aka-open-inner-sign stringToSign signingKey HMAC_ALG)
         authHeader    (str authData "signature=" signature)
         headers       (.getHeaders request)


### PR DESCRIPTION
- current code receives a 401 signature does not match error from Akamai
- after reviewing the built strings before being hashed for this code vs. the Node.JS repo code, I found 2 differences in the clojure-built string which when updated worked as expected
